### PR TITLE
fix: blank env keys populating fields with undesirable values

### DIFF
--- a/env.go
+++ b/env.go
@@ -282,7 +282,7 @@ func getOr(key, defaultValue string, defExists bool, envs map[string]string) (va
 	switch {
 	case (!exists || key == "") && defExists:
 		return defaultValue, true
-	case !exists:
+	case !exists || key == "":
 		return "", false
 	}
 


### PR DESCRIPTION
Same issue as seen in #152 with fields that don't specify an env key being populated by a blank key in the host environment. 

This was resolved in 2ed4d368b74a416ae5d9aeab974700cd2d56f5bc but seems to have been re-intoroduced in e244b8ab4ce741f29f37ac56f4ddd67acce3fb73. Adding an additional case to the value check seems to solve it.